### PR TITLE
Update peer dependencies to match package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "graphql": "^0.12.0 || ^0.13.0",
+    "graphql": "^14.0.0",
     "graphql-tag": "^2.9.0",
-    "graphql-tools": "^3.0.0"
+    "graphql-tools": "^4.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",


### PR DESCRIPTION
I suspect this was unintentionally left as is after the last update