### PR TITLE
Peer dependencies: add graphql v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "graphql": "^0.12.0 || ^0.13.0 || ^0.14.0",
+    "graphql": "^0.12.0 || ^0.13.0 || ^0.14.0 || ^14.0.0",
     "graphql-tag": "^2.0.0",
     "graphql-tools": "^3.0.0 || ^4.0.0"
   },


### PR DESCRIPTION
This library already runs graphql v14 as a dev dependency. This version
should be allowed as a peer dependency in order to prevent installation
warnings.